### PR TITLE
Straylight correction

### DIFF
--- a/src/sophi_hrt_pipe/PSF.py
+++ b/src/sophi_hrt_pipe/PSF.py
@@ -500,7 +500,7 @@ def select_tiptilt(a,i,K):
     a1=np.concatenate((firsta,a[(2*K+1):])) #0 is for the offset term
     return a1
 
-def OTF(a,a_d,RHO,THETA,ap,norm=None,K=2,tiptilt=True):
+def OTF(a,a_d,RHO,THETA,ap,norm=None,K=2,tiptilt=True,ideal=False):
     """
     This function calculates the OTFs of a circular aperture for  incident
     wavefronts with aberrations given by a set of Zernike coefficients.
@@ -532,6 +532,8 @@ def OTF(a,a_d,RHO,THETA,ap,norm=None,K=2,tiptilt=True):
             norma=norma_otf
             #norma=np.max(np.abs(otf)[:])
             otf=otf/norma #Normalization of the OTF
+            if not ideal:
+                otf = add_straylight_to_otf(otf)
         else:
             norma=1
         otf=otf[...,np.newaxis]#To create a 3rd dummy axis    
@@ -559,6 +561,39 @@ def OTF(a,a_d,RHO,THETA,ap,norm=None,K=2,tiptilt=True):
             else:
                 norma[i]=1
     return otf,norma
+
+def add_straylight_to_otf(otf):
+    """input otf must be normalised"""
+    print('Hello!')
+    A1   = 1       # weight for PD-MTF
+    A2   = 0       # weight for near-field straylight
+    A3   = 0.1     # weight for far-field straylight
+    A4   = 0       # global straylight
+    B2   = 1       # standard dev. for near-field straylight
+    B3   = 300    # standard dev. for far-field straylight
+    
+    A = sum([A1,A2,A3,A4]) #re-normalise so sum(weights) = 1
+    A1 /= A
+    A2 /= A
+    A3 /= A
+    
+    IMSCALE = 0.5
+    
+    w = otf.shape[0]
+    freqscale = 1./(w*IMSCALE)
+    x = np.arange(w)
+    y = np.arange(w)
+    
+    X,Y = np.meshgrid(x,y)
+    X = X*freqscale
+    Y = Y*freqscale
+    XC = X[int(w/2)-1,int(w/2)-1]
+    YC = Y[int(w/2)-1,int(w/2)-1]
+    R = (X-XC)**2 + (Y-YC)**2
+    
+    otf_new = A1*otf + A3*np.exp(-2*np.pi**2*(B3)**2*R)
+
+    return otf_new
 
 def Qfactor(Hk,nuc,N,gamma=gamma1,reg=0.1):
     """
@@ -832,7 +867,7 @@ def object_estimate(ima,a,a_d,reg=0.1,wind=True,cobs=0,cut=29,low_f=0.2,tiptilt=
 
     #Apply MTF of ideal telescope
     if aberr_cor:
-        Hk_th,_ = OTF(np.zeros(a.shape),a_d,RHO,THETA,ap,norm=True,K=Ok.shape[2],tiptilt=tiptilt)
+        Hk_th,_ = OTF(np.zeros(a.shape),a_d,RHO,THETA,ap,norm=True,K=Ok.shape[2],tiptilt=tiptilt,ideal=True)
         O=Hk_th[...,0]*O
 
     Oshift=np.fft.fftshift(O)

--- a/src/sophi_hrt_pipe/PSF.py
+++ b/src/sophi_hrt_pipe/PSF.py
@@ -500,7 +500,7 @@ def select_tiptilt(a,i,K):
     a1=np.concatenate((firsta,a[(2*K+1):])) #0 is for the offset term
     return a1
 
-def OTF(a,a_d,RHO,THETA,ap,norm=None,K=2,tiptilt=True,ideal=False):
+def OTF(a,a_d,RHO,THETA,ap,norm=None,K=2,tiptilt=True,ideal=False,straylight_corr=True):
     """
     This function calculates the OTFs of a circular aperture for  incident
     wavefronts with aberrations given by a set of Zernike coefficients.
@@ -532,7 +532,7 @@ def OTF(a,a_d,RHO,THETA,ap,norm=None,K=2,tiptilt=True,ideal=False):
             norma=norma_otf
             #norma=np.max(np.abs(otf)[:])
             otf=otf/norma #Normalization of the OTF
-            if not ideal:
+            if not ideal or not straylight_corr:
                 otf = add_straylight_to_otf(otf)
         else:
             norma=1
@@ -784,7 +784,7 @@ def meritl(e,cut=None):
     return L
 
 def object_estimate(ima,a,a_d,reg=0.1,wind=True,cobs=0,cut=29,low_f=0.2,tiptilt=False,
-                    noise='default',aberr_cor=False):
+                    noise='default',aberr_cor=False,straylight_corr=False):
     """
     This function restores an image or an array of images employing a given
     set of Zernike coefficients.
@@ -831,7 +831,7 @@ def object_estimate(ima,a,a_d,reg=0.1,wind=True,cobs=0,cut=29,low_f=0.2,tiptilt=
                 gamma=[1,0] #To account only for the 1st image
 
     #OTFs
-    Hk,normhk=OTF(a,a_d,RHO,THETA,ap,norm=True,K=Ok.shape[2],tiptilt=tiptilt)
+    Hk,normhk=OTF(a,a_d,RHO,THETA,ap,norm=True,K=Ok.shape[2],tiptilt=tiptilt,straylight_corr=straylight_corr)
     
     #Restoration
     Q=Qfactor(Hk,gamma=gamma,reg=reg,nuc=nuc,N=N)
@@ -867,7 +867,7 @@ def object_estimate(ima,a,a_d,reg=0.1,wind=True,cobs=0,cut=29,low_f=0.2,tiptilt=
 
     #Apply MTF of ideal telescope
     if aberr_cor:
-        Hk_th,_ = OTF(np.zeros(a.shape),a_d,RHO,THETA,ap,norm=True,K=Ok.shape[2],tiptilt=tiptilt,ideal=True)
+        Hk_th,_ = OTF(np.zeros(a.shape),a_d,RHO,THETA,ap,norm=True,K=Ok.shape[2],tiptilt=tiptilt,ideal=True,straylight_corr=False)
         O=Hk_th[...,0]*O
 
     Oshift=np.fft.fftshift(O)
@@ -896,7 +896,7 @@ def is_notebook() -> bool:
         return False      # Probably standard Python interpreter
 
 def stokes_restoration(stokes_data,coefs,sly = slice(0,2048), slx = slice(0,2048),rest='lofdahl', gamma2=0.1,denoise=False,
-                       wind_opt=True, low_f=0.1,num_iter=10,aberr_cor=False,padding=True,cavity=None):
+                       wind_opt=True, low_f=0.1,num_iter=10,aberr_cor=False,straylight_corr=False,padding=True,cavity=None):
     """
     This function restores a cube of Stokes data from a given set of
     Zernike coefficients.
@@ -971,7 +971,7 @@ def stokes_restoration(stokes_data,coefs,sly = slice(0,2048), slx = slice(0,2048
                         im0_roi = stokes_data[sly,slx,i,j] #* edge_mask
                         im0_roi = np.pad(im0_roi, pad_width=((pad_width_roi, pad_width_roi), (pad_width_roi, pad_width_roi)),\
                                       mode='symmetric')
-                        noise=object_estimate(im0_roi,coefs,0,reg=gamma2,wind=wind_opt,low_f=low_f,noise=noise,aberr_cor=aberr_cor)[2]
+                        noise=object_estimate(im0_roi,coefs,0,reg=gamma2,wind=wind_opt,low_f=low_f,noise=noise,aberr_cor=aberr_cor,straylight_corr=straylight_corr)[2]
                         noise = cv2.resize(noise.astype('float32'),im0.shape,interpolation=cv2.INTER_LANCZOS4)
                 else:
                     noise=noise_filt #To use always the same noise_filt (I at continuum)   
@@ -1059,7 +1059,7 @@ def edge_masking(stokes, mask, cavity=None):
 
 
 
-def fran_restore(stokes_data, tobs, mask=None, sly = slice(0,2048), slx = slice(0,2048), rest='lofdahl', gamma2 = 0.1, low_f=0.1, denoise=False, num_iter=10, aberr_cor = False, padding=True, cavity=None, PD_f = '/data/slam/home/calchetti/hrt_pipeline/csv/PD_result.csv'):
+def fran_restore(stokes_data, tobs, mask=None, sly = slice(0,2048), slx = slice(0,2048), rest='lofdahl', gamma2 = 0.1, low_f=0.1, denoise=False, num_iter=10, aberr_cor = False, straylight_corr=False, padding=True, cavity=None, PD_f = '/data/slam/home/calchetti/hrt_pipeline/csv/PD_result.csv'):
     #Input parameters
     # mask=None # mask of the field_stop and limb
     # rest='lofdahl' #'lofdahl','lucy-richardson'or 'unsupervised_wiener'. Type of restoration (Here only lofdahl is implemented)
@@ -1127,7 +1127,7 @@ def fran_restore(stokes_data, tobs, mask=None, sly = slice(0,2048), slx = slice(
     res_stokes, res_cavity = stokes_restoration(stokes_data_edge,coefs,sly=sly,slx=slx,rest=rest, gamma2=gamma2,
                                     denoise=denoise,
                                     wind_opt=wind_opt,low_f=low_f,
-                                    num_iter=num_iter, aberr_cor=aberr_cor,padding=padding, cavity=cavity)
+                                    num_iter=num_iter, aberr_cor=aberr_cor, straylight_corr=straylight_corr,padding=padding, cavity=cavity)
     
     if mask is not None:
         res_stokes[mask==0] = stokes_data[mask==0]

--- a/src/sophi_hrt_pipe/hrt_pipe.py
+++ b/src/sophi_hrt_pipe/hrt_pipe.py
@@ -174,17 +174,18 @@ def phihrt_pipe(input_json_file):
         CTmode = input_dict['CTmode']
         VtoQU = input_dict['VtoQU']
         
-        if isinstance(input_dict['PSFstokes'],bool) and isinstance(input_dict['PSFaberr'],bool):
+        if isinstance(input_dict['PSFstokes'],bool) and isinstance(input_dict['PSFaberr'],bool) and isinstance(input_dict['PSFstraylight'],bool):
             PSFstokes = {'PD_f': "/data/slam/home/calchetti/hrt_pipeline/csv/PD_result.csv",
                          'deconvolution':input_dict['PSFstokes'],
                          'aberration_correction':input_dict['PSFaberr'],
+                         'straylight_correction':input_dict['PSFstraylight'],
                          'gamma2':0.02,
                          'low_f':0.8,
                          'roi':False,
                          'method':'lofdahl'}
         else:
             PSFstokes = input_dict['PSFstokes']
-            for k,v in zip(['PD_f','low_f','gamma2','aberration_correction','roi','method'],["/data/slam/home/calchetti/hrt_pipeline/csv/PD_result.csv",0.8,0.02,True,False,'lofdahl'])  :
+            for k,v in zip(['PD_f','low_f','gamma2','aberration_correction','straylight_correction','roi','method'],["/data/slam/home/calchetti/hrt_pipeline/csv/PD_result.csv",0.8,0.02,True,True,False,'lofdahl']):
                 if k not in PSFstokes.keys():
                     PSFstokes[k] = v
         # PSFaberr = input_dict['PSFaberr']  
@@ -1079,12 +1080,13 @@ def phihrt_pipe(input_json_file):
             
             if cavity_c:
                 restore_results = fran_restore(data[...,scan], datetime.datetime.fromisoformat(hdr_arr[scan]['DATE-OBS']), rest=PSFstokes['method'], mask=mask, sly=psfy, slx=psfx,
-                                             gamma2=PSFstokes['gamma2'], low_f=PSFstokes['low_f'], aberr_cor=PSFstokes['aberration_correction'], 
+                                             gamma2=PSFstokes['gamma2'], low_f=PSFstokes['low_f'], aberr_cor=PSFstokes['aberration_correction'], straylight_corr=PSFstokes['straylight_correction'],
                                              cavity=cavity[rows,cols], PD_f = PSFstokes['PD_f'])
                 res_stokes, coefs, cavity = restore_results
             else:
                 restore_results = fran_restore(data[...,scan], datetime.datetime.fromisoformat(hdr_arr[scan]['DATE-OBS']), rest=PSFstokes['method'], mask=mask, sly=psfy, slx=psfx,
-                                             gamma2=PSFstokes['gamma2'], low_f=PSFstokes['low_f'], aberr_cor=PSFstokes['aberration_correction'], 
+                                             gamma2=PSFstokes['gamma2'], low_f=PSFstokes['low_f'], aberr_cor=PSFstokes['aberration_correction'],
+                                             straylight_corr=PSFstokes['straylight_correction'], 
                                              cavity=None, PD_f = PSFstokes['PD_f'])
                 res_stokes, coefs = restore_results
                 cavity = None
@@ -1094,7 +1096,7 @@ def phihrt_pipe(input_json_file):
             # res_stokes, _ = demod_hrt(res_stokes,pmp_temp)
 
             data[...,scan] = res_stokes
-            hdr_arr[scan]['CAL_PSF'] = '{0:s} PSF deconv; gamma2={1:f}; low_f={2:f}; aberration: {3:}'.format(PSFstokes['method'],PSFstokes['gamma2'],PSFstokes['low_f'],PSFstokes['aberration_correction'])
+            hdr_arr[scan]['CAL_PSF'] = '{0:s} PSF deconv; gamma2={1:f}; low_f={2:f}; aberration: {3:}'.format(PSFstokes['method'],PSFstokes['gamma2'],PSFstokes['low_f'],PSFstokes['aberration_correction'],PSFstokes['straylight_correction'])
             ##
             
             hdr_arr[scan]['CAL_ZER'] = str(list(np.round(coefs,5)))


### PR DESCRIPTION
Added the straylight term to the core of the OTF in function `OTF`. An extra argument was needed such that the `OTF` function still provides an ideal Telescope MTF if `aberr_corr` is set to `True`, and the call in `object_estimate` was adjusted accordingly.

Added straylight_corr argument to all necessary functions in `PSF.py`. Default set to False. 

Added straylight_correction to `PSFstokes`. If `PSFstraylight` and `PSFaberr` both not in input_dict, set to True for both. Also added to output header in `CAL_PSF` comment.