### PR TITLE
wcs correction with hmi within pipeline

### DIFF
--- a/src/sophi_hrt_pipe/hrt_hmi_wcs_correction.py
+++ b/src/sophi_hrt_pipe/hrt_hmi_wcs_correction.py
@@ -17,7 +17,7 @@ from sunpy.coordinates import SphericalScreen
 
 warnings.filterwarnings("ignore", category=sunpy.util.SunpyMetadataWarning)
 
-VERSION = '0.0.1'
+VERSION = '1.0.0'
 
 def get_descriptor(filename, telescope='hrt'):
     descriptor = filename.split('phi-{0}-'.format(telescope))[1].split('_')[0]

--- a/src/sophi_hrt_pipe/hrt_pipe.py
+++ b/src/sophi_hrt_pipe/hrt_pipe.py
@@ -893,7 +893,13 @@ def phihrt_pipe(input_json_file):
             Ic_mask[...,scan] = Ic_temp
             AR_mask[...,scan] = AR_temp
             hdr_arr[scan]['CAL_NORM'] = round(I_c[scan],4)
-        
+
+            # add keyword to header specifying the used sub-region sly and slx (as for CRPIX, the BEG is +1, first pixel is always 1)
+            hdr_arr[scan].set('CAL_SRB1',slx.start+1, 'Sub Region Begin along Axis 1', after='CAL_REAL')
+            hdr_arr[scan].set('CAL_SRE1',slx.stop, 'Sub Region End along Axis 1', after='CAL_SRB1')
+            hdr_arr[scan].set('CAL_SRB2',sly.start+1, 'Sub Region Begin along Axis 2', after='CAL_SRE1')
+            hdr_arr[scan].set('CAL_SRE2',sly.stop, 'Sub Region End along Axis 2', after='CAL_SRB2')
+
         limb_mask = np.array(limb_mask, dtype=bool)
         limb_percent_mask = np.array(limb_percent_mask, dtype=bool)
         

--- a/src/sophi_hrt_pipe/hrt_pipe.py
+++ b/src/sophi_hrt_pipe/hrt_pipe.py
@@ -13,9 +13,9 @@ from .utils import printc, bcolors, get_data, fits_get_sampling, check_size, che
 from .processes import setup_header, apply_dark_correction, load_and_process_flat, load_cavity, prefilter_correction, prefilter_correction_WLS, normalise_flat, unsharp_masking, flat_correction, apply_field_stop, hot_pixel_mask, load_ghost_field_stop, polarimetric_registration, wavelength_registration, demod_hrt, crosstalk_2D_ItoQUV, crosstalk_auto_VtoQU, CT_VtoQU, write_out_intermediate, data_hdr_kw, limb_ellipse, average_registration
 
 from .inversions import generate_l2, create_output_filenames, CE_output
-from .coordinates import muSO_map
+from .coordinates import muSO_map, ccd2HGS
 from .hrt_fdt_wcs_correction import run_FDT_correction, get_descriptor, correct_wcs_with_limb
-from .hrt_fdt_wcs_correction import VERSION as wcs_version
+from .hrt_hmi_wcs_correction import run_HMI_correction
 
 from .PSF import fran_restore
 
@@ -1226,10 +1226,39 @@ def phihrt_pipe(input_json_file):
             if not good:
                 out_ce = CE_output(data[...,scan].copy(), wave_axis_arr[scan], cpos_arr[scan])
                 im = out_ce[2]*np.cos(out_ce[3]*np.pi/180); del out_ce
+
                 if wcs_update.lower() == 'fdt':
                     printc('-->>>>>>> Running FDT WCS correction on the BLOS file',bcolors.OKGREEN)
                     new_wcs = run_FDT_correction(im*limb_mask[...,scan], htemp, False, print_values=True)
+                    from .hrt_fdt_wcs_correction import VERSION as wcs_version
                 
+                elif wcs_update.lower() == 'hmi':
+                    hmi_lim= (-89,89)
+                    centerFoV = ccd2HGS(htemp, np.array([[htemp['NAXIS1']//2, htemp['NAXIS2']//2],
+                                            [htemp['NAXIS1']//2, 0],
+                                            [htemp['NAXIS1']//2, htemp['NAXIS2']-1],
+                                            [0, htemp['NAXIS2']//2],
+                                            [htemp['NAXIS1']-1, htemp['NAXIS2']//2]]))
+                    point = np.nanmean(centerFoV[2]) # longitude, latitude is not checked
+                    
+                    if point > hmi_lim[0] and point < hmi_lim[1]:
+                        printc('-->>>>>>> Running HMI WCS correction on the BLOS file',bcolors.OKGREEN)
+                        try:
+                            new_wcs = run_HMI_correction(im*limb_mask[...,scan], htemp, verbose = False, filename = None, print_values = False, hmi_path = None, crota_manual_correction = 0.15, local_drms = True)
+                            from .hrt_hmi_wcs_correction import VERSION as wcs_version
+                        except Exception as e:
+                            printc(f"Error while correcting with HMI. The code will continue.\nThis was the error: {e}",bcolors.FAIL)
+                            new_wcs = {'CROTA':[None]}
+                    else:
+                        printc('-->>>>>>> Running FDT WCS correction on the BLOS file because the FoV is not in HMI view',bcolors.WARNING)
+                        wcs_update = 'fdt'
+                        from .hrt_fdt_wcs_correction import VERSION as wcs_version
+                        try:
+                            new_wcs = run_FDT_correction(im*limb_mask[...,scan], htemp, False, print_values=True)
+                        except Exception as e:
+                            printc(f"Error while correcting with FDT. The code will continue.\nThis was the error: {e}",bcolors.FAIL)
+                            new_wcs = {'CROTA':[None]}
+
                 for k,v in new_wcs.items():
                     if v[0] is not None:
                         hdr_arr[scan][k] = v[0]

--- a/src/sophi_hrt_pipe/processes.py
+++ b/src/sophi_hrt_pipe/processes.py
@@ -6,7 +6,7 @@ from astropy.io import fits
 import scipy.optimize as spo
 
 from .utils import get_data, fits_get_sampling, filling_data, compare_IMGDIRX, compare_cpos, printc, bcolors, fits_get_sampling, filling_data, compare_IMGDIRX, compare_cpos, load_fits, image_derivative, fft_shift, SPG_shifts_FFT, stokes_reshape, find_nearest
-from .coordinates import solarRotation, SCVelocityResidual, meridionalFlow, SCGravitationalRedshift, convectiveBlueshift, mu_angle, center_coord
+from .coordinates import solarRotation, SCVelocityResidual, meridionalFlow, SCGravitationalRedshift, convectiveBlueshift, mu_angle, center_coord, muSO_map, CLV
 import os
 import time
 import cv2
@@ -1990,6 +1990,33 @@ def elliptical_mask(shape,p):
 
     return mask
 
+def elliptical_mu_map(shape,p):
+    """
+    Ellipse mask
+
+    Parameters
+    ----------
+    shape : tuple
+            shape of the mask
+    p : list
+        [a,b,h,k,A] - ellipse axes (x,y), centers (x,y) and angle
+
+    Returns
+    -------
+    mumap: numpy.ndarray
+          mu value map using the values from the ellipse
+    """    
+    a,b,h,k,A = p
+    x,y = np.meshgrid(np.arange(shape[1]),np.arange(shape[0]))
+    # ellipse defined as the normalized distance from the center
+    ell = ((x-h)*np.cos(A)+(y-k)*np.sin(A))**2/a**2+((x-h)*np.sin(A)-(y-k)*np.cos(A))**2/b**2
+    ell = np.where(ell>1,0,ell)
+    # mu map
+    mumap = np.sqrt(1-ell**2)
+
+    return mumap
+
+
 def fit_plane(data, mask=None, order=1):
 
     """
@@ -2076,7 +2103,7 @@ def subROIconstrast(img, img_mask, windowSize, windowSeparation):
             if img_mask[roi].sum() == 4*windowSize**2:
                 temp = img[roi].copy()
                 # detrend
-                temp /= fit_plane(temp.copy(),order=5)[0]
+                # temp /= fit_plane(temp.copy(),order=5)[0]
                 contrast[i,j] = np.nanstd(temp)/np.nanmean(temp)
             
     return contrast
@@ -2198,7 +2225,10 @@ def limb_ellipse(img, hdr, field_stop, AR_mask, verbose=True, percent=False, fit
         #     windowSize = 384
         # else:
         windowSize = int(256//hdr['NBIN1'])
-        contrast256 = subROIconstrast(img.copy(), (field_stop*mask98)>0, windowSize, windowSize)
+        # clv = CLV(muSO_map(hdr,img.shape))
+        clv = CLV(elliptical_mu_map(img.shape,p.x))
+        contrast256 = subROIconstrast(img.copy()/clv, (field_stop*mask98)>0, windowSize, windowSize)
+        # contrast256 = subROIconstrast(img.copy(), (field_stop*mask98)>0, windowSize, windowSize)
         i,j = np.unravel_index(np.argmax(contrast256),contrast256.shape)
         sly,slx = slice(i-windowSize,i+windowSize), slice(j-windowSize,j+windowSize)
         print('\nHigh contrast slices: ',sly,slx,'\n')


### PR DESCRIPTION
CLV is used instead of fit_plane to find the high contrast area. the CLV is done using a mu map coming from the ellipse limb fit because the WCS are too bad. Also, HMI can now be used to correct for the WCS with direct connection to drms at MPS. For this, use wcs_update:"hmi"